### PR TITLE
Update with readRDS() comment

### DIFF
--- a/intro-spatial.Rmd
+++ b/intro-spatial.Rmd
@@ -587,6 +587,7 @@ right panel.)
 
 ```{r}
 rm(lnd84) # remove the lnd object
+# we will load it back in later with readRDS(file = "data/lnd84.Rds")
 ```
 
 ## Attribute joins


### PR DESCRIPTION
While working through the current version of "intro-spatial-rl.pdf", I noticed it is not up-to-date with the code included in the intro-spatial.Rmd document. In particular, the line for the code to load lnd84 back in (readRDS()) was not in the pdf, but is in the .Rmd file. (I'm sure there may be other discrepancies.) I believe that a lot of users (like myself) would like to work through the PDF rather than the .Rmd, so it would be helpful to have the PDF document updated each time the code in the .Rmd is changed. Thanks!